### PR TITLE
Reenable all tests

### DIFF
--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -2484,7 +2484,7 @@ describe('parser', () => {
       i18nextParser.end(fakeFile)
     })
 
-    it.only('emits a `error` event if the catalog is not valid json', (done) => {
+    it('emits a `error` event if the catalog is not valid json', (done) => {
       const i18nextParser = new i18nTransform({
         output: 'test/locales/$LOCALE/$NAMESPACE.json',
       })


### PR DESCRIPTION
### Why am I submitting this PR

I noticed that only a single test is executed since https://github.com/i18next/i18next-parser/commit/10f3d69fc3db47a05197cf784228613418fc4179#diff-fdc851b37e3e94937316ea7b0a3d2cdb4a727931fe4a12772e6ffb8cac29fd53. I assume that this is quite obvious when running the tests for future versions, but better be safe that nothing breaks in the future due to this.

### Does it fix an existing ticket?

No

### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] tests are included and pass: `yarn test` (see [details here](https://github.com/i18next/i18next-parser/blob/master/docs/development.md#tests))
- [ ] documentation is changed or added
